### PR TITLE
修复插件在新版本下无法使用的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-from wox import Wox, WoxAPI
 import time
 import json
 import traceback
@@ -7,8 +5,7 @@ import logging
 import clipboard
 import sys
 
-reload(sys)
-sys.setdefaultencoding("utf-8")
+from wox import Wox, WoxAPI
 
 LOG_FILE = "./logs/log_tips.log"
 
@@ -30,12 +27,12 @@ class Main(Wox):
 
         results = []
         results.append({
-            "Title": u'stroe tip : "%s"' % key,
-            "SubTitle": u'tips: "%s"' % key,
+            "Title": 'stroe tip : "%s"' % key,
+            "SubTitle": 'tips : "%s"' % key,
             "IcoPath": "Images/pic.png",
             "JsonRPCAction": {
                 "method": "store_tip",
-                "parameters": [key, ],
+                "parameters": [key],
                 "dontHideAfterAction": True
             }
         })
@@ -76,7 +73,7 @@ class Main(Wox):
                 "JsonRPCAction": {
                     "method": "delete_tip",
                     "parameters": [tip['updated_time']],
-                    "dontHideAfterAction": False
+                    "dontHideAfterAction": True
                 }
             })
         return results
@@ -94,6 +91,7 @@ class Main(Wox):
             with open(self.TIPS_FILE, "w") as f:
                 for tip in tips:
                     f.write(json.dumps(tip) + "\n")
+            WoxAPI.change_query("tip")
         except:
             logging.error(traceback.format_exc())
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,12 @@
 {
     "ID":"B4D3B69656E14D44865C8D818EAE47C6",
     "ActionKeyword":"tip",
-    "Name":"tips",
+    "Name":"tips.fix",
     "Description":"快速记录你的小想法",
-    "Author":"ev01ing",
-    "Version":"1.1.0",
+    "Author":"magicdmer",
+    "Version":"1.2.0",
     "Language":"python",
-    "Website":"https://github.com/ev01ing/Wox.Plugin.Tips",
+    "Website":"https://github.com/magicdmer/Wox.Plugin.Tips",
     "IcoPath": "Images\\pic.png", 
     "ExecuteFileName":"main.py"
 }

--- a/readme.md
+++ b/readme.md
@@ -11,14 +11,6 @@ wpm install tips
 
 
 
-#### python依赖
+#### python3依赖
 
-插件使用了time, json, clipboard包，使用前请安装依赖包
-
-
-#### 中文无法使用的解决办法
-
-1. 找到系统的默认字符集，一般为gbk
-2. 找到wox.py的位置，安装目录下的。 可参考 C:\Users\users\AppData\Local\Wox\app-1.3.524\JsonRPC 
-3. 将`class wox`的`__init__`第一行改为
-`rpc_request = json.loads(sys.argv[1].decode("gbk").encode("utf-8"))`
+插件使用了clipboard包，使用前请安装依赖包


### PR DESCRIPTION
经过测试，不需要额外操作就可以完美支持中文，难道之前wox用的python2？